### PR TITLE
fix: Setting saturation params on logistic model when producing forec…

### DIFF
--- a/streamlit_prophet/lib/dataprep/format.py
+++ b/streamlit_prophet/lib/dataprep/format.py
@@ -533,6 +533,8 @@ def prepare_future_df(
         Lib configuration dictionary.
     resampling : Dict
         Resampling specifications.
+    params : Dict
+        Dictionary containing all model parameters
 
     Returns
     -------
@@ -559,7 +561,7 @@ def prepare_future_df(
             freq=dates["forecast_freq"],
         )
         future = pd.DataFrame(future_dates, columns=["ds"])
-        future = add_cap_and_floor_cols(future, params)
+    future = add_cap_and_floor_cols(future, params)
     return future, datasets
 
 

--- a/streamlit_prophet/lib/dataprep/format.py
+++ b/streamlit_prophet/lib/dataprep/format.py
@@ -511,6 +511,7 @@ def prepare_future_df(
     load_options: Dict[Any, Any],
     config: Dict[Any, Any],
     resampling: Dict[Any, Any],
+    params: Dict[Any, Any],
 ) -> Tuple[pd.DataFrame, Dict[Any, Any]]:
     """Applies data preparation to the dataset provided with future regressors.
 
@@ -558,6 +559,7 @@ def prepare_future_df(
             freq=dates["forecast_freq"],
         )
         future = pd.DataFrame(future_dates, columns=["ds"])
+        future = add_cap_and_floor_cols(future, params)
     return future, datasets
 
 

--- a/streamlit_prophet/lib/dataprep/split.py
+++ b/streamlit_prophet/lib/dataprep/split.py
@@ -185,6 +185,8 @@ def make_future_df(
         Lib configuration dictionary.
     resampling : Dict
         Resampling specifications.
+    params : Dict
+        Dictionary containing all model parameters
 
     Returns
     -------

--- a/streamlit_prophet/lib/dataprep/split.py
+++ b/streamlit_prophet/lib/dataprep/split.py
@@ -159,6 +159,7 @@ def make_future_df(
     load_options: Dict[Any, Any],
     config: Dict[Any, Any],
     resampling: Dict[Any, Any],
+    params: Dict[Any, Any],
 ) -> Dict[Any, Any]:
     """Adds future dataframe in datasets dictionary's values.
 
@@ -192,7 +193,7 @@ def make_future_df(
     """
     datasets["full"] = df.copy()
     future, datasets = prepare_future_df(
-        datasets, dates, date_col, target_col, dimensions, load_options, config, resampling
+        datasets, dates, date_col, target_col, dimensions, load_options, config, resampling, params
     )
     future = clean_future_df(future, cleaning)
     datasets["future"] = future

--- a/streamlit_prophet/lib/models/prophet.py
+++ b/streamlit_prophet/lib/models/prophet.py
@@ -260,6 +260,7 @@ def forecast_future(
         load_options,
         config,
         resampling,
+        params,
     )
     models["future"] = instantiate_prophet_model(params, use_regressors=use_regressors, dates=dates)
     models["future"].fit(datasets["full"], seed=config["global"]["seed"])


### PR DESCRIPTION
## Description

Issue when setting saturation params and forecasting into the future. Root cause cap/floor columns not defined in future data frame.

![image](https://user-images.githubusercontent.com/37738513/150314478-89a54e2f-0382-40a1-8523-de0bc4b61cb8.png)

## Related Issue



## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/artefactory/streamlit_prophet}/blob/main/CODE_OF_CONDUCT.md) document.
- [ x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/streamlit_prophet}/blob/main/CONTRIBUTING.md) guide.
- [ x] I've updated the code style using `make format-code`.
- [ x] I've written tests for all new methods and classes that I created.
- [ x] I've written the docstring in Google format for all the methods and classes that I used.
